### PR TITLE
Correct capitalization of RMagick library

### DIFF
--- a/lib/paperback/cover.rb
+++ b/lib/paperback/cover.rb
@@ -1,5 +1,5 @@
 require 'pathname'
-require 'rmagick'
+require 'RMagick'
 
 module Paperback
   class Cover


### PR DESCRIPTION
This is needed on case sensitive file systems.
