### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Add this line to your application's Gemfile:
 And then execute:
 
     $ bundle
+    $ bundle binstubs paperback
 
 Or install it yourself as:
 


### PR DESCRIPTION
- Use homebrew-cask to install Pandoc
- Remove optional PATH instruction for BasicTex
- Add install step for generating paperback binstub
