### PR TITLE
Use URL to review pull requests

### DIFF
--- a/features/review.feature
+++ b/features/review.feature
@@ -8,7 +8,7 @@ Feature: Review
     Then the output should contain:
       """
       Usage:
-        paperback review
+        paperback review [PULL_REQUEST_URL]
 
       Review a pull request
       """

--- a/lib/paperback/cli.rb
+++ b/lib/paperback/cli.rb
@@ -41,9 +41,9 @@ module Paperback
       AssetSync.sync
     end
 
-    desc 'review', 'Review a pull request'
-    def review(pull_request_id)
-      Hub.checkout pull_request_id
+    desc 'review [PULL_REQUEST_URL]', 'Review a pull request'
+    def review(pull_request_url)
+      Hub.checkout pull_request_url
       preview
     end
 

--- a/lib/paperback/hub.rb
+++ b/lib/paperback/hub.rb
@@ -2,19 +2,8 @@ require 'cocaine'
 
 module Paperback
   class Hub
-    def self.checkout(pull_request_id)
-      pull_request_url = "#{repository_url}/pull/#{pull_request_id}"
+    def self.checkout(pull_request_url)
       Cocaine::CommandLine.new('hub checkout', pull_request_url).run
-    end
-
-    private
-
-    def self.repository_url
-      "https://github.com/#{username}/#{Git.repository_name}"
-    end
-
-    def self.username
-      Git.origin_url.split(%r{[:/]})[-2]
     end
   end
 end

--- a/spec/paperback/hub_spec.rb
+++ b/spec/paperback/hub_spec.rb
@@ -2,37 +2,11 @@ require 'spec_helper'
 
 describe Paperback::Hub do
   describe '.checkout' do
-    before do
-      @pull_request_id = 1
-    end
+    it 'runs hub checkout' do
+      command_line = stub_command_line
+      pull_request_url = 'https://github.com/user/project/pull/1'
 
-    context 'when cloned over HTTPS' do
-      it 'runs hub checkout' do
-        command_line = stub_hub_checkout('https://github.com/a/b.git')
-
-        Paperback::Hub.checkout @pull_request_id
-
-        verify_command_line command_line
-      end
-    end
-
-    context 'when cloned over SSH' do
-      it 'runs hub checkout' do
-        command_line = stub_hub_checkout('git@github.com:a/b.git')
-
-        Paperback::Hub.checkout @pull_request_id
-
-        verify_command_line command_line
-      end
-    end
-
-    def stub_hub_checkout(origin_url)
-      allow(Paperback::Git).to receive(:origin_url) { origin_url }
-      stub_command_line ''
-    end
-
-    def verify_command_line(command_line)
-      pull_request_url = "https://github.com/a/b/pull/#{@pull_request_id}"
+      Paperback::Hub.checkout pull_request_url
 
       expect(Cocaine::CommandLine).to have_received(:new)
         .with('hub checkout', pull_request_url)

--- a/spec/support/cocaine_macros.rb
+++ b/spec/support/cocaine_macros.rb
@@ -1,5 +1,5 @@
 module CocaineMacros
-  def stub_command_line(output, exit_status = 0)
+  def stub_command_line(output = '', exit_status = 0)
     command_line = double(
       Cocaine::CommandLine,
       exit_status: exit_status,


### PR DESCRIPTION
- Remove assumptions about Git config
- Simplify implementation
