### PR TITLE
Update AWS environment variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ S3 integration:
 
     AWS_ACCESS_KEY_ID
     AWS_BUCKET
-    AWS_SECRET_KEY_ID
+    AWS_SECRET_ACCESS_KEY
 
 ## Contributing
 


### PR DESCRIPTION
Fixes:

```
Aws secret access key can't be blank (AssetSync::Config::Invalid)
```
