### PR TITLE
Override potential git configurations

### DIFF
--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -1,7 +1,7 @@
 Given /^I create a git repo named "([^"]*)"$/ do |name|
-  git 'init'
+  git 'init --template=/usr/share/git-core/templates'
   git 'add .'
-  git 'commit -m "Initial commit"'
+  git 'commit --no-gpg-sign --message "Initial commit"'
   git "remote add origin git@github.com:example/#{name}.git"
 end
 


### PR DESCRIPTION
- If a developer has a git template, standard git-init followed by
  adding a remote could cause a failure to add the `origin` remote.
- For developers who have configured default git commit signing,
  `git-commit` opens an interactive prompt asking for the GPG
  passphrase, which (if ignored) causes the commit step to fail.
