### PR TITLE
Raise if no remote is configured

### DIFF
--- a/lib/paperback/git.rb
+++ b/lib/paperback/git.rb
@@ -11,7 +11,13 @@ module Paperback
 
     def self.origin_url
       git = new("config --get remote.origin.url")
-      git.run.output.strip
+      output = git.run.output.strip
+
+      if output.empty?
+        fail "No origin remote present."
+      end
+
+      output
     end
 
     def self.repository_name

--- a/spec/paperback/git_spec.rb
+++ b/spec/paperback/git_spec.rb
@@ -10,6 +10,12 @@ describe Paperback::Git do
       expect(command_line).to have_received(:run)
       expect(actual).to eq(expected)
     end
+
+    it "raises if there is no origin remote configured" do
+      stub_command_line("\n")
+
+      expect { Paperback::Git.origin_url }.to raise_error(/no origin remote/i)
+    end
   end
 
   describe ".repository_name" do


### PR DESCRIPTION
This allowed me to test-build before creating the remote as part of the first
push.
