### PR TITLE
Make links darker

### DIFF
--- a/lib/paperback/templates/pdf.latex
+++ b/lib/paperback/templates/pdf.latex
@@ -107,16 +107,16 @@ $endif$
               pdfauthor={$author-meta$},
               pdftitle={$title-meta$},
               colorlinks=true,
-              urlcolor=cyan,
-              linkcolor=cyan]{hyperref}
+              urlcolor=blue,
+              linkcolor=blue]{hyperref}
 \else
   \usepackage[unicode=true,
               bookmarks=true,
               pdfauthor={$author-meta$},
               pdftitle={$title-meta$},
               colorlinks=true,
-              urlcolor=cyan,
-              linkcolor=cyan]{hyperref}
+              urlcolor=blue,
+              linkcolor=blue]{hyperref}
 \fi
 \hypersetup{breaklinks=true, pdfborder={0 0 0}}
 $if(strikeout)$


### PR DESCRIPTION
I received feedback that the color of links was light cyan and doesn't have enough contrast. Before and after screenshots:
## ![screen shot 2015-03-06 at 2 16 58 pm](https://cloud.githubusercontent.com/assets/54260/6532156/7835636a-c40c-11e4-8479-0254a43be028.png)

![screen shot 2015-03-06 at 2 22 42 pm](https://cloud.githubusercontent.com/assets/54260/6532157/783646fe-c40c-11e4-85de-ef666aac883f.png)
