### PR TITLE
Include --smart in Pandoc invocation

### DIFF
--- a/lib/paperback/pandoc.rb
+++ b/lib/paperback/pandoc.rb
@@ -18,6 +18,7 @@ module Paperback
       end
 
       args.push(
+        "--smart",
         "--output=#{package.target(format)}",
         package.target(:md)
       )

--- a/spec/paperback/pandoc_spec.rb
+++ b/spec/paperback/pandoc_spec.rb
@@ -16,14 +16,14 @@ describe Paperback::Pandoc do
       end
     end
 
-    it "adds --output=format to the given arguments" do
+    it "adds --smart and --output=format to the given arguments" do
       stub_pandoc("--version", "pandoc 1.11.1")
-      stub_pandoc("--foo --bar --output=html ", "")
+      stub_pandoc("--foo --bar --smart --output=html ", "")
       allow(@package).to receive(:target).with("format").and_return("html")
 
       @pandoc.generate("format", %w(--foo --bar))
 
-      expect_pandoc("--foo --bar --output=html ")
+      expect_pandoc("--foo --bar --smart --output=html ")
     end
   end
 


### PR DESCRIPTION
```
`-S`, `--smart`
:   Produce typographically correct output, converting straight quotes
    to curly quotes, `---` to em-dashes, `--` to en-dashes, and
    `...` to ellipses. Nonbreaking spaces are inserted after certain
    abbreviations, such as "Mr." (Note: This option is significant only when
    the input format is `markdown`, `markdown_strict`, `textile` or `twiki`.
    It is selected automatically when the input format is `textile` or the
    output format is `latex` or `context`, unless `--no-tex-ligatures`
    is used.)
```
- Can be disabled (or customized) by setting `PAPERBACK_PANDOC_OPTIONS` in the
  environment

Related #124, thoughtbot/maybe_haskell#46
