### PR TITLE
Change Docker WORKDIR to fix Thor output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ COPY . $PAPERBACK_HOME
 ENV PATH $PAPERBACK_HOME/exe:$PATH
 
 # Create directory to be mounted as data volume
-RUN mkdir -p /book
-WORKDIR /book
+RUN mkdir -p /src
+WORKDIR /src
 
 ENTRYPOINT ["paperback"]
 CMD ["help"]

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ extensions to pull in code samples from a bundled example application.
 1. Generate a new book.
 
         $ mkdir DIRECTORY && cd DIRECTORY
-        $ docker run --volume $PWD:/book thoughtbot/paperback new
+        $ docker run --volume $PWD:/src thoughtbot/paperback new
 
 1. [Push it to GitHub](http://git.io/bxAu).
 
 1. Build all packages and formats or a subset.
 
-        $ docker run --volume $PWD:/book thoughtbot/paperback build
-        $ docker run --volume $PWD:/book thoughtbot/paperback build --format pdf --package book
+        $ docker run --volume $PWD:/src thoughtbot/paperback build
+        $ docker run --volume $PWD:/src thoughtbot/paperback build --format pdf --package book
 
 ## Formatting
 


### PR DESCRIPTION
https://github.com/thoughtbot/paperback/issues/127

It appears that Thor will strip the generator's name (e.g. book) from
its status outputs if the PWD is at the root of the file system and has
the same name (e.g. /book).
