### PR TITLE
Add paperback check command to verify dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,15 @@ FROM ruby:2.1.5
 MAINTAINER thoughtbot <support@thoughtbot.com>
 
 # Install packages
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        cm-super=0.3.4-9 \
-        fonts-inconsolata=001.010-5 \
-        fonts-lmodern=2.004.4-5 \
-        locales=2.19-18 \
-        texlive-fonts-recommended=2014.20141024-2 \
-        texlive-latex-extra=2014.20141024-1 \
-        texlive-xetex=2014.20141024-2 && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		cm-super=0.3.4-9 \
+		fonts-inconsolata=001.010-5 \
+		fonts-lmodern=2.004.4-5 \
+		locales=2.19-18 \
+		texlive-fonts-recommended=2014.20141024-2 \
+		texlive-latex-extra=2014.20141024-1 \
+		texlive-xetex=2014.20141024-2 \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Set the locale
 ENV LANG en_US.UTF-8
@@ -22,9 +21,9 @@ RUN echo "$LANG UTF-8" >> /etc/locale.gen && locale-gen
 # Install Pandoc
 ENV PANDOC_VERSION 1.13.2
 ENV PANDOC_PACKAGE pandoc-$PANDOC_VERSION-1-amd64.deb
-RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/$PANDOC_PACKAGE && \
-    dpkg -i $PANDOC_PACKAGE && \
-    rm $PANDOC_PACKAGE
+RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/$PANDOC_PACKAGE \
+	&& dpkg -i $PANDOC_PACKAGE \
+	&& rm $PANDOC_PACKAGE
 
 # Setup Paperback
 ENV PAPERBACK_HOME /usr/local/paperback
@@ -41,5 +40,5 @@ ENV PATH $PAPERBACK_HOME/exe:$PATH
 RUN mkdir -p /src
 WORKDIR /src
 
-ENTRYPOINT ["paperback"]
-CMD ["help"]
+COPY ./entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ group :development, :test do
   gem "rake", "~> 10.3.2"
   gem "rspec", "~> 3.0.0"
   gem "rubocop", "0.25.0"
+  gem "docker-api"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,10 @@ GEM
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.1)
     diff-lcs (1.2.5)
+    docker-api (1.22.1)
+      excon (>= 0.38.0)
+      json
+    excon (0.45.4)
     ffi (1.9.6)
     gherkin (2.12.2)
       multi_json (~> 1.3)
@@ -95,6 +99,7 @@ DEPENDENCIES
   bundler-audit (= 0.3.1)
   cocaine (~> 0.5.4)
   coderay (~> 1.1.0)
+  docker-api
   kindlegen (~> 2.9.1)
   nokogiri (~> 1.6.3.1)
   pdf-reader (~> 1.3.3)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+commands=$(paperback help | cut -f 4 -d" " -s)
+
+if grep -q "$1" <<< "$commands"; then
+	paperback "$@"
+else
+	exec "$@"
+fi

--- a/lib/paperback/cli.rb
+++ b/lib/paperback/cli.rb
@@ -15,6 +15,11 @@ module Paperback
       Paperback::Commands::Clean.call
     end
 
+    desc "check", "Check Paperback dependencies"
+    def check
+      Paperback::Commands::Check.call
+    end
+
     desc "new", "Create a new Paperback project in the current directory"
     def new
       Paperback::Commands::New.call

--- a/lib/paperback/commands.rb
+++ b/lib/paperback/commands.rb
@@ -1,4 +1,5 @@
 require "paperback/commands/build"
+require "paperback/commands/check"
 require "paperback/commands/clean"
 require "paperback/commands/copy_assets"
 require "paperback/commands/new"

--- a/lib/paperback/commands/check.rb
+++ b/lib/paperback/commands/check.rb
@@ -1,0 +1,80 @@
+module Paperback
+  module Commands
+    class Check
+      def self.call
+        new.check_dependencies!
+      end
+
+      def check_dependencies!
+        puts "Checking Paperback dependencies..."
+        missing_dependencies = dependencies.select do |dependency|
+          printf "%-30s", "Checking for #{dependency[:name]}..."
+          if present?(dependency[:check])
+            puts "Found"
+          else
+            puts "Missing"
+            dependency
+          end
+        end
+
+        if missing_dependencies.empty?
+          puts "All dependencies satisfied."
+        else
+          puts "Missing dependencies:"
+          missing_dependencies.each do |dependency|
+            puts "  • " + dependency[:message]
+          end
+        end
+      end
+
+      def dependencies
+        [
+          {
+            name: "LaTeX",
+            check: "xelatex -v",
+            message: <<-MSG
+LaTeX (http://latex-project.org/ftp.html)
+      ∟ Huge download—start it now!
+            MSG
+          },
+          # {
+          #   name: "KindleGen",
+          #   check: "kindlegen -v",
+          #   message: <<-MSG,
+# KindleGen (http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211)
+      # ∟ Put the kindlegen executable on your path, e.g., in /usr/local/bin
+          #   MSG
+          # },
+          {
+            name: "Inconsolata",
+            check: "#{LIST_FONTS} | grep -i inconsolata",
+            message: <<-MSG,
+Inconsolata (http://www.levien.com/type/myfonts/inconsolata.html)
+      ∟ Download and install the font
+            MSG
+          },
+          {
+            name: "Open Sans",
+            check: %(#{LIST_FONTS} | grep -i "Open Sans"),
+            message: <<-MSG
+Open Sans (https://www.google.com/fonts#UsePlace:use/Collection:Open+Sans)
+      ∟ Download and install the font
+            MSG
+          },
+        ]
+      end
+
+      def present?(command)
+        `#{command}`
+        $?.success?
+      end
+
+      LIST_FONTS = %{(if ([ "$(uname)" = "Darwin" ]); then
+  /usr/X11/bin/fc-list
+else
+  fc-list
+fi)}
+      private_constant :LIST_FONTS
+    end
+  end
+end

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -1,0 +1,27 @@
+require "docker"
+
+Docker.options = { read_timeout: 600, write_timeout: 600 }
+
+describe "Dockerfile" do
+  it "passes paperback check" do
+    expect(ENV).to have_key("DOCKER_HOST"), "Set DOCKER_HOST before running specs."
+    result = docker("check")
+
+    expect(result).to eq "Checking Paperback dependencies...
+Checking for LaTeX...         Found
+Checking for Inconsolata...   Found
+Checking for Open Sans...     Found
+All dependencies satisfied.
+"
+  end
+
+  def docker(cmd)
+    container = Docker::Image.build_from_dir(".").run(cmd)
+    output = []
+    container.attach(stdout: true, stderr: true) do |_, chunk|
+      output << chunk
+    end
+    container.wait["StatusCode"]
+    output.join
+  end
+end


### PR DESCRIPTION
Create a quick script to ensure that dependencies have been satisfied on the
Docker image (and anywhere else, really, since this could still be run
locally). Add a spec that runs and verifies this by building the image.

This lays some groundwork for Dockerfile refactors I have in mind to support a
couple of use-cases:
- Insert a new image that only handles Pandoc/LaTeX, then base a
  Paperback image on that instead of directly on ruby-2-2
- Don't use ruby-2-2 as it's a bloated image providing more than we
  really need. RVM-based images worked well for Scriptorium's Softcover
  image.

A couple of semi-related changes snuck in here that could possibly be split
into separate commits:
- Change entrypoint to a quick bash script that checks whether the
  command is a subcommand of Paperback and `exec`s otherwise (this is a
  standard practice in writing Dockerfiles when the command is
  unrecognized)
- Switch to tabs in Dockerfile (since it's shell, this makes more sense
  to me than spaces)
- Minor change in apt-get command to join update/install lines per
  [Dockerfile Best-Practices](https://docs.docker.com/articles/dockerfile_best-practices/#sort-multi-line-arguments)
  example.
