### PR TITLE
Strip cover image EXIF data

### DIFF
--- a/features/build.feature
+++ b/features/build.feature
@@ -155,3 +155,9 @@ Feature: Build
       | build/a-nice-adventure/a-nice-adventure.epub        |
       | build/a-nice-adventure/a-nice-adventure.mobi        |
       | build/a-nice-adventure/a-nice-adventure.pdf         |
+
+  Scenario: Successive runs
+    When I successfully run `paperback build`
+    And I successfully run `cp -r build/ public/`
+    And I successfully run `paperback build`
+    Then I successfully run `diff --recursive build/a-nice-adventure/images/ public/a-nice-adventure/images/`

--- a/lib/paperback/cover.rb
+++ b/lib/paperback/cover.rb
@@ -7,7 +7,7 @@ module Paperback
       png = source("png")
       image = Magick::Image.read(pdf) { self.density = 400 }.first
       image.resize 1000, 1000
-      image.write png
+      image.write(png) { self["png", "exclude-chunk"] = "date,time" }
       png
     end
 


### PR DESCRIPTION
https://github.com/thoughtbot/paperback/issues/141

The EXIF data (e.g. timestamps) was updating on the resized image even
when the original image had not changed. This was an issue for projects
that version the build artifacts, as it caused Git to treat the file as
modified. Calling `#strip!` removes all profiles and comments from the
resized image.
