### PR TITLE
Fix Docker installation link, which was 404'ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ extensions to pull in code samples from a bundled example application.
 
 ## Installation
 
-1. [Set up Docker](https://docs.docker.com/installation).
+1. [Set up Docker](https://docs.docker.com/engine/installation/).
 
 1. Get the [latest release](https://github.com/thoughtbot/paperback/releases)
    and load the image.


### PR DESCRIPTION
The new link points to the default Mac page,
but that page also links to Linux and Windows install pages.
