### PR TITLE
Adding CircleCI config

### DIFF
--- a/.circle.yml
+++ b/.circle.yml
@@ -1,0 +1,30 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/paperback
+    docker:
+      - image: circleci/ruby:2.4.1
+        environment:
+          CIRCLECI: true
+    steps:
+      - run: git config --global user.email "bruno@thoughtbot.com" && git config --global user.name "Bruno Antunes"
+
+      - checkout
+
+      - type: cache-restore
+        name: Restore bundle cache
+        key: paperback-{{ checksum "Gemfile.lock" }}
+
+      - run: wget https://github.com/jgm/pandoc/releases/download/1.19.2.1/pandoc-1.19.2.1-1-amd64.deb
+
+      - run: sudo dpkg -i pandoc-1.19.2.1-1-amd64.deb
+
+      - run: bundle install --path vendor/bundle
+
+      - type: cache-save
+        name: Store bundle cache
+        key: paperback-{{ checksum "Gemfile.lock" }}
+        paths:
+          - vendor/bundle
+
+      - run: bundle exec rake


### PR DESCRIPTION
Not sure if this is working the correct way. Maybe getting it to download the `thoughtbot/paperback` container and running the specs there would be better.