### PR TITLE
Introduce a website format, used on thoughtbot.com

### DIFF
--- a/lib/paperback/formats.rb
+++ b/lib/paperback/formats.rb
@@ -1,6 +1,7 @@
 require "paperback/formats/epub"
 require "paperback/formats/html"
 require "paperback/formats/pdf"
+require "paperback/formats/website"
 require "paperback/formats/table_of_contents"
 require "paperback/formats/table_of_contents_renderer"
 
@@ -8,15 +9,16 @@ module Paperback
   module Formats
     FORMAT_CLASSES = [
       Paperback::Formats::HTML,
+      Paperback::Formats::Website,
       Paperback::Formats::PDF,
       Paperback::Formats::EPUB,
       Paperback::Formats::TableOfContents
     ]
 
     class << self
-      def select(package, extension = nil)
+      def select(package, desired_format = nil)
         all(package).select do |format|
-          extension.nil? || format.extension == extension
+          desired_format.nil? || format.type == desired_format
         end
       end
 

--- a/lib/paperback/formats/base.rb
+++ b/lib/paperback/formats/base.rb
@@ -11,6 +11,10 @@ module Paperback
         fail NotImplementedError
       end
 
+      def type
+        extension
+      end
+
       def generate
         Paperback::Markdown.generate package
         prepare

--- a/lib/paperback/formats/website.rb
+++ b/lib/paperback/formats/website.rb
@@ -1,0 +1,45 @@
+require "paperback/formats/pandoc_base"
+
+module Paperback
+  module Formats
+    class Website < PandocBase
+      def type
+        "website"
+      end
+
+      def extension
+        "html.zip"
+      end
+
+      private
+
+      def args
+        [
+          "-t chunkedhtml",
+          "--template=#{website_template_path}",
+          "--chunk-template=%i.html",
+          "--split-level=2",
+          "--lua-filter=#{clickable_headers_filter_path}",
+          "--toc-depth=2",
+          "--toc"
+        ]
+      end
+
+      def website_template_path
+        File.expand_path "../../templates/website.erb", __FILE__
+      end
+
+      def clickable_headers_filter_path
+        File.expand_path "../../templates/clickable_headers.lua", __FILE__
+      end
+
+      def css_path
+        File.expand_path "../../assets/css/application.css", __FILE__
+      end
+
+      def google_fonts_path
+        File.expand_path "../../assets/google_fonts.html", __FILE__
+      end
+    end
+  end
+end

--- a/lib/paperback/templates/clickable_headers.lua
+++ b/lib/paperback/templates/clickable_headers.lua
@@ -1,0 +1,7 @@
+function Header (h)
+  -- if AST object is header type, it is passed through this function
+
+  -- update the content
+  h.content = pandoc.Link(h.content, '#' .. h.identifier)
+  return h
+end

--- a/lib/paperback/templates/website.erb
+++ b/lib/paperback/templates/website.erb
@@ -1,0 +1,28 @@
+$if(description-meta)$
+<% content_for :meta_description, "$description-meta$" %>
+$endif$
+$if(title)$
+<% content_for :book_title, "$title$" %>
+$endif$
+$if(subtitle)$
+<% content_for :book_subtitle, "$subtitle$" %>
+$endif$
+$if(pagetitle)$
+<% content_for :chapter_title, "$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$" %>
+$endif$
+$if(next.url)$
+<% content_for :next_chapter_url, "$next.url$" %>
+$endif$
+$if(previous.url)$
+<% content_for :previous_chapter_url, "$previous.url$" %>
+$endif$
+<% content_for :toc do %>
+$table-of-contents$
+<% end %>
+<% content_for :chapter do %>
+$body$
+
+<style>
+$highlighting-css$
+</style>
+<% end %>


### PR DESCRIPTION
This introduces a new format, `Website` which uses pandoc's ChunkedHTML
functionality, with a custom template to generate Erb partials that can
then be used by thoughtbot.com.

There was previously no way to have a format which was different than
the extension/built-in types of pandoc, so this introduces an optional
separation between the name of the format in Paperback and the pandoc
format.
