### PR TITLE
Support building on Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=arm64 ruby:3.2.2
+FROM ruby:3.2.2
 MAINTAINER thoughtbot <support@thoughtbot.com>
 
 # Install packages
@@ -21,9 +21,13 @@ ENV LANGUAGE $LANG
 ENV LC_ALL $LANG
 RUN echo "$LANG UTF-8" >> /etc/locale.gen && locale-gen
 
+# Automatically bring --platform into scope, so we can pick the correct .deb.
+# This has been tested with arm64 and amd64 values.
+ARG TARGETARCH
+
 # Install Pandoc
 ENV PANDOC_VERSION 3.1.8
-ENV PANDOC_PACKAGE pandoc-$PANDOC_VERSION-1-arm64.deb
+ENV PANDOC_PACKAGE pandoc-$PANDOC_VERSION-1-$TARGETARCH.deb
 RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/$PANDOC_PACKAGE && \
     dpkg -i $PANDOC_PACKAGE && \
     rm $PANDOC_PACKAGE


### PR DESCRIPTION
This required two changes:

- Don't force `FROM --platform`

  This shouldn't be in a `Dockerfile`, or then it can only be built on that platform. `--platform` (`--arch` in Podman) can and should be specified from the outside during build (as the README documents).

  Perhaps this was intentional to prevent attempting a build that won't succeed (see next fix), but it doesn't just prevent the build with a meaningful error, it attempts to move forward on the wrong base image anyway and gives a confusing `exec error` later.

- Use `TARGETARCH` to select the correct pandoc artifact

  This is one of [many variables available](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/) to know which arch you are building for or targeting. In this case, it works directly as a suffix for the pandoc `.deb` file. It should work for both `arm64` or `amd64` making this change behavior-neutral, though I was only able to test with the latter[^1].

[^1]: I'd love to add CI that verifies the image builds for OSX and Linux, would y'all be open to that? It could one day be extended to push to (e.g.) Docker Hub, so folks can just pull and run.