### PR TITLE
Add support for fenced divs

### DIFF
--- a/lib/paperback/pandoc.rb
+++ b/lib/paperback/pandoc.rb
@@ -18,7 +18,7 @@ module Paperback
       end
 
       args.push(
-        "--from=markdown+smart",
+        "--from=markdown+smart+fenced_divs",
         "--output=#{package.target(format)}",
         package.target(:md)
       )


### PR DESCRIPTION
This is an extension for Pandoc Markdown that allows you to output divs
without using html markup, like fenced code blocks.

We can use these for admonitions in our Markdown.

https://pandoc.org/chunkedhtml-demo/8.18-divs-and-spans.html

Note: I initially tried to enable the alerts extension, which enabled
GitHub style Markdown Alerts, but that is only available with the Pandoc
`gfm` format. Switching to that format for our markdown broke several
other things, so I went this direction. It could be good to explore that
in the future.